### PR TITLE
Change makefile to conventional usage (make, make install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,17 @@ Step 2: Install the development packages for x11, cairo, and lv2 if not done yet
 Step 3: Building and installing into the default lv2 directory (/usr/lib/lv2/) is easy. Simply call:
 
 ```
+make
 sudo make install
 ```
 
 from the directory where you downloaded the repository files.
 
-For installation into an alternative directory (e.g., /usr/local/lib/lv2), modify line 2 in the makefile.
+For installation into an alternative directory (e.g., /usr/local/lib/lv2), change the variable `INSTALL_DIR` while installing:
+
+```
+sudo make INSTALL_DIR=/usr/local/lib/lv2 install
+```
 
 ## Running
 

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ BShaprGUI.so: ./src/BShaprGUI.cpp
 	mkdir -p $(BUNDLE)
 	$(CXX) $< $(TK) -o $(BUNDLE)/$@ -std=c++11 -shared -fvisibility=hidden -DPUGL_HAVE_CAIRO -fPIC -DPIC `pkg-config --cflags --libs lv2 x11 cairo`
 
-install: $(BUNDLE)
+install: 
 	mkdir -p $(INSTALL_DIR)
 	rm -rf $(INSTALL_DIR)/$(BUNDLE)
 	cp -R $(BUNDLE) $(INSTALL_DIR)


### PR DESCRIPTION
This separation of building with `make` and installation `make install` enables users to build without sudo and then installation as root.

This is also the conventional usage of make.