### PR TITLE
Use separate tmp directories for targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -145,14 +145,13 @@ $(BUNDLE): clean $(DSP_OBJ) $(GUI_OBJ) $(DSP_CV_OBJ) $(GUI_CV_OBJ)
 all: $(BUNDLE)
 
 $(DSP_OBJ): $(DSP_SRC)
-	@echo -n Build $(BUNDLE) DSP...
+	@echo Build $(BUNDLE) DSP...
 	@mkdir -p $(BUNDLE)
 	@$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(DSPCFLAGS) -Wl,--start-group $(DSPLFLAGS) $< $(DSP_INCL) -Wl,--end-group -o $(BUNDLE)/$@
 	@echo \ done.
 
 $(GUI_OBJ): $(GUI_SRC)
-	@echo -n Build $(BUNDLE) GUI...
-	@mkdir -p $(BUNDLE)
+	@echo Build $(BUNDLE) GUI...
 	@mkdir -p $(BUNDLE)/tmp
 	@cd $(BUNDLE)/tmp; $(CC) $(CPPFLAGS) $(GUIPPFLAGS) $(CFLAGS) $(GUICFLAGS) $(addprefix ../../, $(GUI_C_INCL)) -c
 	@cd $(BUNDLE)/tmp; $(CXX) $(CPPFLAGS) $(GUIPPFLAGS) $(CXXFLAGS) $(GUICFLAGS) $(addprefix ../../, $< $(GUI_CXX_INCL)) -c
@@ -161,23 +160,22 @@ $(GUI_OBJ): $(GUI_SRC)
 	@echo \ done.
 
 $(DSP_CV_OBJ): $(DSP_SRC)
-	@echo -n Build $(BUNDLE) \(CV version\) DSP...
+	@echo Build $(BUNDLE) \(CV version\) DSP...
 	@mkdir -p $(BUNDLE)
 	@$(CXX) $(CPPFLAGS) -DSUPPORTS_CV $(CXXFLAGS) $(LDFLAGS) $(DSPCFLAGS) -Wl,--start-group $(DSPLFLAGS) $< $(DSP_INCL) -Wl,--end-group -o $(BUNDLE)/$@
 	@echo \ done.
 
 $(GUI_CV_OBJ): $(GUI_SRC)
-	@echo -n Build $(BUNDLE) \(CV version\) GUI...
-	@mkdir -p $(BUNDLE)
-	@mkdir -p $(BUNDLE)/tmp
-	@cd $(BUNDLE)/tmp; $(CC) $(CPPFLAGS) -DSUPPORTS_CV $(GUIPPFLAGS) $(CFLAGS) $(GUICFLAGS) $(addprefix ../../, $(GUI_C_INCL)) -c
-	@cd $(BUNDLE)/tmp; $(CXX) $(CPPFLAGS) -DSUPPORTS_CV $(GUIPPFLAGS) $(CXXFLAGS) $(GUICFLAGS) $(addprefix ../../, $< $(GUI_CXX_INCL)) -c
-	@$(CXX) $(CPPFLAGS) -DSUPPORTS_CV $(GUIPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(GUICFLAGS) -Wl,--start-group $(GUILFLAGS) $(BUNDLE)/tmp/*.o -Wl,--end-group -o $(BUNDLE)/$@
-	@rm -rf $(BUNDLE)/tmp
+	@echo Build $(BUNDLE) \(CV version\) GUI...
+	@mkdir -p $(BUNDLE)/tmp_cv
+	@cd $(BUNDLE)/tmp_cv; $(CC) $(CPPFLAGS) -DSUPPORTS_CV $(GUIPPFLAGS) $(CFLAGS) $(GUICFLAGS) $(addprefix ../../, $(GUI_C_INCL)) -c
+	@cd $(BUNDLE)/tmp_cv; $(CXX) $(CPPFLAGS) -DSUPPORTS_CV $(GUIPPFLAGS) $(CXXFLAGS) $(GUICFLAGS) $(addprefix ../../, $< $(GUI_CXX_INCL)) -c
+	@$(CXX) $(CPPFLAGS) -DSUPPORTS_CV $(GUIPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(GUICFLAGS) -Wl,--start-group $(GUILFLAGS) $(BUNDLE)/tmp_cv/*.o -Wl,--end-group -o $(BUNDLE)/$@
+	@rm -rf $(BUNDLE)/tmp_cv
 	@echo \ done.
 
 install:
-	@echo -n Install $(BUNDLE) to $(DESTDIR)$(LV2DIR)...
+	@echo Install $(BUNDLE) to $(DESTDIR)$(LV2DIR)...
 	@$(INSTALL) -d $(DESTDIR)$(LV2DIR)/$(BUNDLE)
 	@$(INSTALL) -d $(DESTDIR)$(LV2DIR)/$(BUNDLE)/inc
 	@$(INSTALL_PROGRAM) -m755 $(B_OBJECTS) $(DESTDIR)$(LV2DIR)/$(BUNDLE)


### PR DESCRIPTION
makefile:
Use temporary directories that are unique per target, as builds
otherwise break on concurrency issues.
Use echo with newlines as it is easier to understand in which target
issues occur.

Fixes #19